### PR TITLE
adding lazy loading

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -7,6 +7,10 @@ export default defineNuxtPlugin((nuxt) => {
   if (process.client) {
     const options = nuxt.$config.public.gtm
 
+    if (!options.id) {
+      return
+    }
+    
     const router = useRouter()
 
     const pluginOptions: VueGtmUseOptions = {


### PR DESCRIPTION
adding lazy loading, after add you can use custom gtm plugin, example to change the tag after loading the module

```ts
// pugins/gtm.ts
import {defineNuxtPlugin, useRouter} from 'nuxt/app'
import { createGtm, type VueGtmUseOptions } from '@gtm-support/vue-gtm'

export default defineNuxtPlugin((nuxt) => {
  if (process.client) {
    const options = nuxt.$config.public.gtm

    const router = useRouter()

    const pluginOptions: VueGtmUseOptions = {
      ...options,
      vueRouter: options.enableRouterSync && router ? router as VueGtmUseOptions['vueRouter'] : undefined,
      id: 'GTM-YYYYYY'
    }

    nuxt.vueApp.use(createGtm(pluginOptions))
  }
})

```